### PR TITLE
Feature/fix registration logic

### DIFF
--- a/src/EpiEasyEvents/ContentEventHandlersModule.cs
+++ b/src/EpiEasyEvents/ContentEventHandlersModule.cs
@@ -352,12 +352,9 @@ namespace Forte.EpiEasyEvents
             {
                 var interfaceTypes = givenType.GetInterfaces();
 
-                foreach (var it in interfaceTypes)
+                if (interfaceTypes.Any(it => it.IsGenericType && it.GetGenericTypeDefinition() == genericType))
                 {
-                    if (it.IsGenericType && it.GetGenericTypeDefinition() == genericType)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
 
                 if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericType)

--- a/src/EpiEasyEvents/ContentEventHandlersModule.cs
+++ b/src/EpiEasyEvents/ContentEventHandlersModule.cs
@@ -11,7 +11,6 @@ using Forte.EpiEasyEvents.EventHandlers;
 using StructureMap;
 using StructureMap.Graph;
 using StructureMap.Graph.Scanning;
-using StructureMap.TypeRules;
 
 namespace Forte.EpiEasyEvents
 {
@@ -335,19 +334,39 @@ namespace Forte.EpiEasyEvents
         {
             public void ScanTypes(TypeSet types, Registry registry)
             {
-                // Only work on concrete types
-                var typesToRegister = types.FindTypes(TypeClassification.Concretes | TypeClassification.Closed)
-                    .Where(type => type.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IContentEventHandler<,>)));
-                foreach (var typeToRegister in typesToRegister)
+                var interfaceWithTypeTuples = types
+                    .FindTypes(TypeClassification.Concretes | TypeClassification.Closed)
+                    .SelectMany(
+                        type => type.GetInterfaces()
+                            .Where(interfaceType => IsAssignableToGenericType(interfaceType, typeof(IContentEventHandler<,>)) && interfaceType.GetGenericTypeDefinition() != typeof(IContentEventHandler<,>))
+                            .Select(it => new { InterfaceType = it, TypeToRegister = type}));
+
+
+                foreach (var typePair in interfaceWithTypeTuples)
                 {
-                    // Register against all the interfaces implemented
-                    // by this concrete class
-                    var interfacesToRegister = typeToRegister.GetInterfaces();
-                    foreach (var interfaceToRegister in interfacesToRegister)
+                    registry.For(typePair.InterfaceType).Use(typePair.TypeToRegister);
+                }
+            }
+
+            private static bool IsAssignableToGenericType(Type givenType, Type genericType)
+            {
+                var interfaceTypes = givenType.GetInterfaces();
+
+                foreach (var it in interfaceTypes)
+                {
+                    if (it.IsGenericType && it.GetGenericTypeDefinition() == genericType)
                     {
-                        registry.For(interfaceToRegister).Use(typeToRegister);
+                        return true;
                     }
                 }
+
+                if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericType)
+                {
+                    return true;
+                }
+
+                var baseType = givenType.BaseType;
+                return baseType != null && IsAssignableToGenericType(baseType, genericType);
             }
         }
     }


### PR DESCRIPTION
This fixes the logic of event handler registration in DependencyInjection container (StructureMap).

In the current implementation if I have a class:

```cs
public class FooHandler : IContentPublishedHandler<PageData>, IFoo, IBar
{
}
```

this class will be registered in StructureMap as implementation of **every** interface it implements: `IContentPublishedHandler`, `IContentEventHandler`, `IFoo`, `IBar`.

For sure we don't want this to be registered as `IFoo` and `IBar` implementations. From this package perspective, it is sufficient to be registered as `IContentPublishedHandler` implementation