### PR TITLE
Don't try to register abstract EventHandlers

### DIFF
--- a/src/EpiEasyEvents/ServiceCollectionExtensions.cs
+++ b/src/EpiEasyEvents/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private static void RegisterEventHandlers(IServiceCollection services, IEnumerable<Assembly> assemblies)
         {
             var interfaceWithTypeTuples = assemblies.SelectMany(assembly => assembly.GetTypes())
+                .Where(t => t.IsAbstract == false)
                 .SelectMany(
                     type => type.GetInterfaces()
                         .Where(interfaceType => IsAssignableToGenericType(interfaceType, typeof(IContentEventHandler<,>)) && interfaceType.GetGenericTypeDefinition() != typeof(IContentEventHandler<,>))


### PR DESCRIPTION
In case someone defined abstract class implementing one of interfaces provided by this package, ie:

`public abstract class ExampleEventHandler : IContentPublishedHandler<PageData>`

there will be an exception, since DI container will try to instantiate such class.

This PR fixes this