### PR TITLE
#2 Change type constraint to IContentData

### DIFF
--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -9,7 +9,7 @@
 	</packageRestore>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-		<add key="EPiServer" value="http://nuget.episerver.com/feed/packages.svc/" />
+		<add key="EPiServer" value="https://nuget.episerver.com/feed/packages.svc/" />
 	</packageSources>
   <disabledPackageSources />
 	<activePackageSource>

--- a/src/EpiEasyEvents/EventHandlers/IApprovalRequestedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IApprovalRequestedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IApprovalRequestedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IApprovalRequestedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IApprovalRequestingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IApprovalRequestingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IApprovalRequestingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IApprovalRequestingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentCheckedInHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentCheckedInHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentCheckedInHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentCheckedInHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentCheckedOutHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentCheckedOutHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentCheckedOutHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentCheckedOutHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentCheckingInHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentCheckingInHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentCheckingInHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentCheckingInHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentCheckingOutHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentCheckingOutHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentCheckingOutHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentCheckingOutHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentCreatedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentCreatedHandler.cs
@@ -6,5 +6,5 @@ namespace Forte.EpiEasyEvents.EventHandlers
     /// <summary>
     /// Content event args are either SaveContentEventArgs or CopyContentEventArgs, depending on scenario
     /// </summary>
-    public interface IContentCreatedHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContent{}
+    public interface IContentCreatedHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentCreatingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentCreatingHandler.cs
@@ -6,5 +6,5 @@ namespace Forte.EpiEasyEvents.EventHandlers
     /// <summary>
     /// Content event args are either SaveContentEventArgs or CopyContentEventArgs, depending on scenario
     /// </summary>
-    public interface IContentCreatingHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContent{}
+    public interface IContentCreatingHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentDeletedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentDeletedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentDeletedHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContent{}
+    public interface IContentDeletedHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentDeletingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentDeletingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentDeletingHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContent{}
+    public interface IContentDeletingHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentLanguageCreatedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentLanguageCreatedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentLanguageCreatedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentLanguageCreatedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentLanguageCreatingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentLanguageCreatingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentLanguageCreatingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentLanguageCreatingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentLanguageDeletedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentLanguageDeletedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentLanguageDeletedHandler<TContentType>: IContentEventHandler<TContentType, ContentLanguageEventArgs> where TContentType:IContent{}
+    public interface IContentLanguageDeletedHandler<TContentType>: IContentEventHandler<TContentType, ContentLanguageEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentLanguageDeletingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentLanguageDeletingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentLanguageDeletingHandler<TContentType>: IContentEventHandler<TContentType, ContentLanguageEventArgs> where TContentType:IContent{}
+    public interface IContentLanguageDeletingHandler<TContentType>: IContentEventHandler<TContentType, ContentLanguageEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentLoadedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentLoadedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentLoadedHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContent{}
+    public interface IContentLoadedHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentMovedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentMovedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentMovedHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContent{}
+    public interface IContentMovedHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentMovingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentMovingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentMovingHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContent{}
+    public interface IContentMovingHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentPermanentlyDeletedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentPermanentlyDeletedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentPermanentlyDeletedHandler<TContentType>: IContentEventHandler<TContentType, DeleteContentEventArgs> where TContentType:IContent{}
+    public interface IContentPermanentlyDeletedHandler<TContentType>: IContentEventHandler<TContentType, DeleteContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentPermanentlyDeletingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentPermanentlyDeletingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentPermanentlyDeletingHandler<TContentType>: IContentEventHandler<TContentType, DeleteContentEventArgs> where TContentType:IContent{}
+    public interface IContentPermanentlyDeletingHandler<TContentType>: IContentEventHandler<TContentType, DeleteContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentPublishedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentPublishedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentPublishedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentPublishedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentPublishingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentPublishingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentPublishingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentPublishingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentRejectedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentRejectedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentRejectedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentRejectedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentRejectingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentRejectingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentRejectingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentRejectingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentRestoredHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentRestoredHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentRestoredHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContent{}
+    public interface IContentRestoredHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentRestoringHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentRestoringHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentRestoringHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContent{}
+    public interface IContentRestoringHandler<TContentType>: IContentEventHandler<TContentType, MoveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentSavedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentSavedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentSavedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentSavedHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentSavingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentSavingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentSavingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentSavingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentScheduledHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentScheduledHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentScheduledHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentScheduledHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IContentSchedulingHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IContentSchedulingHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IContentSchedulingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContent{}
+    public interface IContentSchedulingHandler<TContentType>: IContentEventHandler<TContentType, SaveContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventHandlers/IDefaultContentLoadedHandler.cs
+++ b/src/EpiEasyEvents/EventHandlers/IDefaultContentLoadedHandler.cs
@@ -3,5 +3,5 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents.EventHandlers
 {
-    public interface IDefaultContentLoadedHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContent{}
+    public interface IDefaultContentLoadedHandler<TContentType>: IContentEventHandler<TContentType, ContentEventArgs> where TContentType:IContentData{}
 }

--- a/src/EpiEasyEvents/EventsRegistry.cs
+++ b/src/EpiEasyEvents/EventsRegistry.cs
@@ -224,7 +224,7 @@ namespace Forte.EpiEasyEvents
                 return;
             }
 
-            var pageType = eventArgs.Content?.GetType() ?? typeof(IContent);
+            var pageType = eventArgs.Content?.GetType() ?? typeof(IContentData);
             var eventHandlers = GetAllEventHandlers(pageType, handlerInterface);
 
             foreach (var handler in eventHandlers)
@@ -239,7 +239,7 @@ namespace Forte.EpiEasyEvents
         {
             var handledContentTypes = pageType.GetInterfaces()
                 .Concat(GetInheritanceHierarchy(pageType))
-                .Where(type => typeof(IContent).IsAssignableFrom(type));
+                .Where(type => typeof(IContentData).IsAssignableFrom(type));
             var handlers = Enumerable.Empty<object>();
             foreach (var handledType in handledContentTypes)
             {

--- a/src/EpiEasyEvents/IContentEventHandler.cs
+++ b/src/EpiEasyEvents/IContentEventHandler.cs
@@ -3,7 +3,7 @@ using EPiServer.Core;
 
 namespace Forte.EpiEasyEvents
 {
-    public interface IContentEventHandler<TContentType, TEventArgsType> where TEventArgsType : ContentEventArgs where TContentType : IContent
+    public interface IContentEventHandler<TContentType, TEventArgsType> where TEventArgsType : ContentEventArgs where TContentType : IContentData
     {
         void Handle(TContentType content, TEventArgsType eventArgs);
     }


### PR DESCRIPTION
Change type constraint to IContentData so that events on blocks can be handled

Fix for #2 